### PR TITLE
同じ数値のimgを表示 #7

### DIFF
--- a/script.js
+++ b/script.js
@@ -65,7 +65,14 @@ function slideJump(steps){
     main.setAttribute("data-index", steps);
 
     // アニメーション
-    let animationType = currentIndex <= nextIndex ? true : false;
+    let animationType = "";
+    if(currentIndex < nextIndex){
+        animationType = "next";
+    }else if(currentIndex > nextIndex){
+        animationType = "before";
+    }else{
+        animationType = "same";
+    };
     animation(currentElement, nextElement, animationType);
 }
 
@@ -73,19 +80,25 @@ function slideJump(steps){
 function animation(currentElement, nextElement, animationType){
     main.innerHTML = "";
     main.append(nextElement);
-
+    
     extra.innerHTML = "";
     extra.append(currentElement);
-
+    
     main.classList.add("expand-animation");
     extra.classList.add("deplete-animation");
-
-    if(animationType){
+    
+    if(animationType === "next"){
         sliderShow.innerHTML = "";
         sliderShow.append(extra);
         sliderShow.append(main);
+    }else if(animationType === "before"){
+        sliderShow.innerHTML = "";
+        sliderShow.append(main);
+        sliderShow.append(extra);
     }else{
         sliderShow.innerHTML = "";
+        main.innerHTML = "";
+        main.append(currentElement);
         sliderShow.append(main);
         sliderShow.append(extra);
     }


### PR DESCRIPTION
現状、sliderDataにsliderItem要素を格納しており、main,extraはそこから参照している。
ただ、同じ数値の番号を選択した場合、同じ要素が参照されるため、最後にレンダリングされるものが優先される。
ーーーーーーーーーーー
変更点は、mainをsliderDataから参照するのではなく、fastFoodsListからimgUrlを引っ張ってきて解決している。